### PR TITLE
Add v128 type and SIMD intrinsics

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,13 @@ include "platform_imports.cwa"
 
 ### Types
 
-There are four types in WebAssembly and therefore CurlyWas:
+There are five types in WebAssembly and therefore CurlyWas:
 
 * `i32`: 32bit integer
 * `i64`: 64bit integer
 * `f32`: 32bit float
 * `f64`: 64bit float
+* `v128`: 128bit vector
 
 There are no unsigned types, but there are unsigned operators where it makes a difference.
 
@@ -81,6 +82,12 @@ Integer numbers can be given either in decimal or hex:
 
 ```
 123, -7878, 0xf00
+```
+
+64 or 128-bit integers are denoted using `i64` or `i128`:
+
+```
+0xabc0i64, 8i128
 ```
 
 For floating point numbers, only the most basic decimal format is currently implemented (no scientific notation or hex-floats, yet):
@@ -399,6 +406,19 @@ And binary files:
 file("font.bin")
 ```
 
+#### SIMD
+
+Intrinsics are available for all WASM SIMD instructions, except for `i8x16.shuffle` and the relaxed SIMD extensions.
+For instructions that refer to lanes, i.e. `*.extract_lane*`, `*.replace_lane`, `v128.store*_lane`, and
+`v128.load*_lane`, the lane number follows the vector argument. For example:
+
+```
+v128.store32_lane(<v128_value>, <lane>, <base-address>[, <offset>, [<align>]]);
+v128.load32_splat(<v128_value>, <lane>, <base-address>[, <offset>, [<align>]]);
+i32x4.extract_lane(<v128_value>, <lane>);
+i32x4.replace_lane(<v128_value>, <lane>, <i32_value>);
+```
+
 #### Advanced sequencing
 
 Sometimes when sizeoptimizing it helps to be able to execute some side-effecty code in the middle an expression.
@@ -430,7 +450,6 @@ The idea of CurlyWas is to be able to hand-craft any valid WASM program, ie. hav
 
 This goal is not yet fully reached, with the following being the main limitations:
 
-* CurlyWas currently only targets MVP web assembly + non-trapping float-to-int conversions. No other post-MVP features are currently supported. Especially "Multi-value" will be problematic as this allows programs that don't map cleanly to an expression tree.
-* Memory intrinsics are still missing, so only (unsigned) 8 and 32 bit integer reads and writes are possible.
+* CurlyWas currently only targets MVP web assembly + non-trapping float-to-int conversions + SIMD. No other post-MVP features are currently supported. Especially "Multi-value" will be problematic as this allows programs that don't map cleanly to an expression tree.
 * `block`s cannot return values, as the branch instructions are missing syntax to pass along a value.
 * `br_table` and `call_indirect` are not yet implemented.

--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ file("font.bin")
 
 #### SIMD
 
-Intrinsics are available for all WASM SIMD instructions, except for `i8x16.shuffle` and the relaxed SIMD extensions.
+Intrinsics are available for all WASM SIMD instructions, except for the relaxed SIMD extensions.
 For instructions that refer to lanes, i.e. `*.extract_lane*`, `*.replace_lane`, `v128.store*_lane`, and
 `v128.load*_lane`, the lane number follows the vector argument. For example:
 
@@ -418,6 +418,14 @@ v128.load32_splat(<v128_value>, <lane>, <base-address>[, <offset>, [<align>]]);
 i32x4.extract_lane(<v128_value>, <lane>);
 i32x4.replace_lane(<v128_value>, <lane>, <i32_value>);
 ```
+
+The format for `i8x16.shuffle` is:
+
+```
+i8x16.shuffle(<v128_a>, <v128_b>, [<lane_0>[, <lane_1>[, ... <lane_16>]]])
+```
+
+Omitted lane arguments default to their index, so providing no lane arguments simply returns the value of `<v128_a>`.
 
 #### Advanced sequencing
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -177,6 +177,7 @@ pub enum DataType {
     I16,
     I32,
     I64,
+    I128,
     F32,
     F64,
 }
@@ -208,6 +209,13 @@ impl Expression {
         match self.expr {
             Expr::I64Const(v) => v,
             _ => panic!("Expected I64Const"),
+        }
+    }
+
+    pub fn const_v128(&self) -> i128 {
+        match self.expr {
+            Expr::V128Const(v) => v,
+            _ => panic!("Expected V128Const"),
         }
     }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -243,6 +243,7 @@ pub enum Expr {
     I64Const(i64),
     F32Const(f32),
     F64Const(f64),
+    V128Const(i128),
     Variable {
         name: String,
         local_id: Option<u32>,
@@ -382,15 +383,17 @@ pub enum Type {
     I64,
     F32,
     F64,
+    V128
 }
 
 impl fmt::Display for Type {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Type::I32 => write!(f, "i32"),
-            Type::I64 => write!(f, "i64"),
-            Type::F32 => write!(f, "f32"),
-            Type::F64 => write!(f, "f64"),
+            Type::I32  => write!(f, "i32"),
+            Type::I64  => write!(f, "i64"),
+            Type::F32  => write!(f, "f32"),
+            Type::F64  => write!(f, "f64"),
+            Type::V128 => write!(f, "v128"),
         }
     }
 }

--- a/src/constfold.rs
+++ b/src/constfold.rs
@@ -319,7 +319,8 @@ fn fold_expr(context: &Context, expr: &mut ast::Expression) {
         ast::Expr::I32Const(_)
         | ast::Expr::I64Const(_)
         | ast::Expr::F32Const(_)
-        | ast::Expr::F64Const(_) => (),
+        | ast::Expr::F64Const(_)
+        | ast::Expr::V128Const(_) => (),
         ast::Expr::Variable { ref name, .. } => {
             if let Some(value) = context.consts.get(name) {
                 expr.expr = value.clone();

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -8,7 +8,7 @@ use wasm_encoder::{
 
 use crate::{
     ast,
-    intrinsics::{Intrinsics, MemInstruction},
+    intrinsics::{Intrinsics, MemInstruction, MemLaneInstruction, LaneInstruction},
     Options,
 };
 
@@ -279,6 +279,7 @@ fn const_instr(expr: &ast::Expression) -> Instruction {
         ast::Expr::F32Const(v) => Instruction::F32Const(v),
         ast::Expr::I64Const(v) => Instruction::I64Const(v),
         ast::Expr::F64Const(v) => Instruction::F64Const(v),
+        ast::Expr::V128Const(v) => Instruction::V128Const(v),
         _ => unreachable!(),
     }
 }
@@ -437,6 +438,7 @@ fn emit_expression<'a>(ctx: &mut FunctionContext<'a>, expr: &'a ast::Expression)
                     emit_expression(ctx, value);
                     ctx.function.instruction(&Instruction::F64Neg);
                 }
+                (V128, Negate) => unreachable!(),
                 (I32, Not) => {
                     emit_expression(ctx, value);
                     ctx.function.instruction(&Instruction::I32Eqz);
@@ -533,6 +535,8 @@ fn emit_expression<'a>(ctx: &mut FunctionContext<'a>, expr: &'a ast::Expression)
                 (F64, Le) => Instruction::F64Le,
                 (F64, Gt) => Instruction::F64Gt,
                 (F64, Ge) => Instruction::F64Ge,
+
+                (V128, _) => unreachable!(),
             });
         }
         ast::Expr::Branch(label) => {
@@ -571,6 +575,9 @@ fn emit_expression<'a>(ctx: &mut FunctionContext<'a>, expr: &'a ast::Expression)
         }
         ast::Expr::F64Const(v) => {
             ctx.function.instruction(&Instruction::F64Const(*v));
+        }
+        ast::Expr::V128Const(v) => {
+            ctx.function.instruction(&Instruction::V128Const(*v));
         }
         ast::Expr::Assign {
             name,
@@ -657,7 +664,8 @@ fn emit_expression<'a>(ctx: &mut FunctionContext<'a>, expr: &'a ast::Expression)
                 (F32, F64) => Some(Instruction::F64PromoteF32),
                 (F64, F32) => Some(Instruction::F32DemoteF64),
 
-                (I32, I32) | (I64, I64) | (F32, F32) | (F64, F64) => None,
+                (I32, I32) | (I64, I64) | (F32, F32) | (F64, F64) | (V128, V128) => None,
+                (V128, _) | (_, V128) => unreachable!(),
             };
             if let Some(inst) = inst {
                 ctx.function.instruction(&inst);
@@ -679,15 +687,65 @@ fn emit_expression<'a>(ctx: &mut FunctionContext<'a>, expr: &'a ast::Expression)
                     memory_index: 0,
                 })
             }
+            fn mem_lane_instruction(
+                inst: MemLaneInstruction,
+                lane: u8,
+                params: &[ast::Expression],
+            ) -> Instruction<'static> {
+                let offset = params
+                    .get(0)
+                    .map(|e| e.const_i32() as u32 as u64)
+                    .unwrap_or(0);
+                let alignment = params.get(1).map(|e| e.const_i32() as u32);
+                (inst.instruction)(MemArg {
+                    offset,
+                    align: alignment.unwrap_or(inst.natural_alignment),
+                    memory_index: 0,
+                }, lane)
+            }
+            fn lane_instruction(
+                inst: LaneInstruction,
+                lane: u8
+            ) -> Instruction<'static> {
+                (inst.instruction)(lane)
+            }
             if let Some(load) = ctx.intrinsics.find_load(name) {
                 emit_expression(ctx, &params[0]);
                 ctx.function
                     .instruction(&mem_instruction(load, &params[1..]));
+            } else if let Some(load_lane) = ctx.intrinsics.find_load_lane(name) {
+                let lane = params
+                    .get(0)
+                    .map(|e| e.const_i32() as u8)
+                    .unwrap();
+                emit_expression(ctx, &params[1]);
+                ctx.function
+                    .instruction(&mem_lane_instruction(load_lane, lane, &params[2..]));
             } else if let Some(store) = ctx.intrinsics.find_store(name) {
                 emit_expression(ctx, &params[1]);
                 emit_expression(ctx, &params[0]);
                 ctx.function
                     .instruction(&mem_instruction(store, &params[2..]));
+            } else if let Some(store_lane) = ctx.intrinsics.find_store_lane(name) {
+                emit_expression(ctx, &params[2]);
+                emit_expression(ctx, &params[0]);
+                let lane = params
+                    .get(1)
+                    .map(|e| e.const_i32() as u8)
+                    .unwrap();
+                ctx.function
+                    .instruction(&mem_lane_instruction(store_lane, lane, &params[3..]));
+            } else if let Some(lane_instr) = ctx.intrinsics.find_lane(name) {
+                emit_expression(ctx, &params[0]);
+                let lane = params
+                    .get(1)
+                    .map(|e| e.const_i32() as u8)
+                    .unwrap();
+                if let Some(_) = lane_instr.param_type {
+                    emit_expression(ctx, &params[2]);
+                }
+                ctx.function
+                    .instruction(&lane_instruction(lane_instr, lane));
             } else {
                 for param in params {
                     emit_expression(ctx, param);
@@ -762,6 +820,7 @@ fn map_type(t: ast::Type) -> ValType {
         ast::Type::I64 => ValType::I64,
         ast::Type::F32 => ValType::F32,
         ast::Type::F64 => ValType::F64,
+        ast::Type::V128 => ValType::V128,
     }
 }
 

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -714,13 +714,14 @@ fn emit_expression<'a>(ctx: &mut FunctionContext<'a>, expr: &'a ast::Expression)
                 ctx.function
                     .instruction(&mem_instruction(load, &params[1..]));
             } else if let Some(load_lane) = ctx.intrinsics.find_load_lane(name) {
+                emit_expression(ctx, &params[2]);
+                emit_expression(ctx, &params[0]);
                 let lane = params
-                    .get(0)
+                    .get(1)
                     .map(|e| e.const_i32() as u8)
                     .unwrap();
-                emit_expression(ctx, &params[1]);
                 ctx.function
-                    .instruction(&mem_lane_instruction(load_lane, lane, &params[2..]));
+                    .instruction(&mem_lane_instruction(load_lane, lane, &params[3..]));
             } else if let Some(store) = ctx.intrinsics.find_store(name) {
                 emit_expression(ctx, &params[1]);
                 emit_expression(ctx, &params[0]);

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -146,6 +146,7 @@ pub fn emit(script: &ast::Script, module_name: &str, options: &Options) -> Vec<u
                             ast::DataType::I16 => 2,
                             ast::DataType::I32 => 4,
                             ast::DataType::I64 => 8,
+                            ast::DataType::I128 => 16,
                             ast::DataType::F32 => 4,
                             ast::DataType::F64 => 8,
                         };
@@ -161,6 +162,8 @@ pub fn emit(script: &ast::Script, module_name: &str, options: &Options) -> Vec<u
                                     .extend_from_slice(&(value.const_i32() as u32).to_le_bytes()),
                                 ast::DataType::I64 => segment_data
                                     .extend_from_slice(&(value.const_i64() as u64).to_le_bytes()),
+                                ast::DataType::I128 => segment_data
+                                    .extend_from_slice(&(value.const_v128() as u128).to_le_bytes()),
                                 ast::DataType::F32 => {
                                     segment_data.extend_from_slice(&value.const_f32().to_le_bytes())
                                 }

--- a/src/intrinsics.rs
+++ b/src/intrinsics.rs
@@ -445,12 +445,11 @@ impl Intrinsics {
 
     pub fn find_load_lane(&self, name: &str) -> Option<MemLaneInstruction> {
         use enc::Instruction as I;
-        use Type::*;
         let ins = match name {
-            "v128.load8_lane" => MemLaneInstruction::new(V128, |memarg, lane| I::V128Load8Lane { memarg: memarg, lane: lane }, 0),
-            "v128.load16_lane" => MemLaneInstruction::new(V128, |memarg, lane| I::V128Load16Lane { memarg: memarg, lane: lane }, 1),
-            "v128.load32_lane" => MemLaneInstruction::new(V128, |memarg, lane| I::V128Load32Lane { memarg: memarg, lane: lane }, 2),
-            "v128.load64_lane" => MemLaneInstruction::new(V128, |memarg, lane| I::V128Load64Lane { memarg: memarg, lane: lane }, 3),
+            "v128.load8_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Load8Lane { memarg: memarg, lane: lane }, 0),
+            "v128.load16_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Load16Lane { memarg: memarg, lane: lane }, 1),
+            "v128.load32_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Load32Lane { memarg: memarg, lane: lane }, 2),
+            "v128.load64_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Load64Lane { memarg: memarg, lane: lane }, 3),
             _ => return None,
         };
         return Some(ins);
@@ -477,12 +476,11 @@ impl Intrinsics {
 
     pub fn find_store_lane(&self, name: &str) -> Option<MemLaneInstruction> {
         use enc::Instruction as I;
-        use Type::*;
         let ins = match name {
-            "v128.store8_lane" => MemLaneInstruction::new(V128, |memarg, lane| I::V128Store8Lane { memarg: memarg, lane: lane }, 0),
-            "v128.store16_lane" => MemLaneInstruction::new(V128, |memarg, lane| I::V128Store16Lane { memarg: memarg, lane: lane }, 1),
-            "v128.store32_lane" => MemLaneInstruction::new(V128, |memarg, lane| I::V128Store32Lane { memarg: memarg, lane: lane }, 2),
-            "v128.store64_lane" => MemLaneInstruction::new(V128, |memarg, lane| I::V128Store64Lane { memarg: memarg, lane: lane }, 3),
+            "v128.store8_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Store8Lane { memarg: memarg, lane: lane }, 0),
+            "v128.store16_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Store16Lane { memarg: memarg, lane: lane }, 1),
+            "v128.store32_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Store32Lane { memarg: memarg, lane: lane }, 2),
+            "v128.store64_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Store64Lane { memarg: memarg, lane: lane }, 3),
             _ => return None,
         };
         return Some(ins);
@@ -533,19 +531,16 @@ impl MemInstruction {
 }
 
 pub struct MemLaneInstruction {
-    pub type_: Type,
     pub instruction: fn(MemArg, Lane) -> enc::Instruction<'static>,
     pub natural_alignment: u32,
 }
 
 impl MemLaneInstruction {
     fn new(
-        type_: Type,
         instruction: fn(MemArg, Lane) -> enc::Instruction<'static>,
         natural_alignment: u32,
     ) -> MemLaneInstruction {
         MemLaneInstruction {
-            type_,
             instruction,
             natural_alignment,
         }

--- a/src/intrinsics.rs
+++ b/src/intrinsics.rs
@@ -446,10 +446,10 @@ impl Intrinsics {
     pub fn find_load_lane(&self, name: &str) -> Option<MemLaneInstruction> {
         use enc::Instruction as I;
         let ins = match name {
-            "v128.load8_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Load8Lane { memarg: memarg, lane: lane }, 0),
-            "v128.load16_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Load16Lane { memarg: memarg, lane: lane }, 1),
-            "v128.load32_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Load32Lane { memarg: memarg, lane: lane }, 2),
-            "v128.load64_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Load64Lane { memarg: memarg, lane: lane }, 3),
+            "v128.load8_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Load8Lane { memarg: memarg, lane: lane }, 0, 0),
+            "v128.load16_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Load16Lane { memarg: memarg, lane: lane }, 1, 1),
+            "v128.load32_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Load32Lane { memarg: memarg, lane: lane }, 2, 2),
+            "v128.load64_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Load64Lane { memarg: memarg, lane: lane }, 3, 3),
             _ => return None,
         };
         return Some(ins);
@@ -477,10 +477,10 @@ impl Intrinsics {
     pub fn find_store_lane(&self, name: &str) -> Option<MemLaneInstruction> {
         use enc::Instruction as I;
         let ins = match name {
-            "v128.store8_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Store8Lane { memarg: memarg, lane: lane }, 0),
-            "v128.store16_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Store16Lane { memarg: memarg, lane: lane }, 1),
-            "v128.store32_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Store32Lane { memarg: memarg, lane: lane }, 2),
-            "v128.store64_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Store64Lane { memarg: memarg, lane: lane }, 3),
+            "v128.store8_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Store8Lane { memarg: memarg, lane: lane }, 0, 0),
+            "v128.store16_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Store16Lane { memarg: memarg, lane: lane }, 1, 1),
+            "v128.store32_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Store32Lane { memarg: memarg, lane: lane }, 2, 2),
+            "v128.store64_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Store64Lane { memarg: memarg, lane: lane }, 3, 3),
             _ => return None,
         };
         return Some(ins);
@@ -490,20 +490,20 @@ impl Intrinsics {
         use enc::Instruction as I;
         use Type::*;
         let ins = match name {
-            "i8x16.extract_lane_s" => LaneInstruction::new(None, I32, |lane| I::I8x16ExtractLaneS { lane: lane }),
-            "i8x16.extract_lane_u" => LaneInstruction::new(None, I32, |lane| I::I8x16ExtractLaneU { lane: lane }),
-            "i8x16.replace_lane" => LaneInstruction::new(Some(I32), V128, |lane| I::I8x16ReplaceLane { lane: lane }),
-            "i16x8.extract_lane_s" => LaneInstruction::new(None, I32, |lane| I::I16x8ExtractLaneS { lane: lane }),
-            "i16x8.extract_lane_u" => LaneInstruction::new(None, I32, |lane| I::I16x8ExtractLaneU { lane: lane }),
-            "i16x8.replace_lane" => LaneInstruction::new(Some(I32), V128, |lane| I::I16x8ReplaceLane { lane: lane }),
-            "i32x4.extract_lane" => LaneInstruction::new(None, I32, |lane| I::I32x4ExtractLane { lane: lane }),
-            "i32x4.replace_lane" => LaneInstruction::new(Some(I32), V128, |lane| I::I32x4ReplaceLane { lane: lane }),
-            "i64x2.extract_lane" => LaneInstruction::new(None, I64, |lane| I::I64x2ExtractLane { lane: lane }),
-            "i64x2.replace_lane" => LaneInstruction::new(Some(I64), V128, |lane| I::I64x2ReplaceLane { lane: lane }),
-            "f32x4.extract_lane" => LaneInstruction::new(None, F64, |lane| I::F32x4ExtractLane { lane: lane }),
-            "f32x4.replace_lane" => LaneInstruction::new(Some(F64), V128, |lane| I::F32x4ReplaceLane { lane: lane }),
-            "f64x2.extract_lane" => LaneInstruction::new(None, F64, |lane| I::F64x2ExtractLane { lane: lane }),
-            "f64x2.replace_lane" => LaneInstruction::new(Some(F64), V128, |lane| I::F64x2ReplaceLane { lane: lane }),
+            "i8x16.extract_lane_s" => LaneInstruction::new(None, I32, |lane| I::I8x16ExtractLaneS { lane: lane }, 0),
+            "i8x16.extract_lane_u" => LaneInstruction::new(None, I32, |lane| I::I8x16ExtractLaneU { lane: lane }, 0),
+            "i8x16.replace_lane" => LaneInstruction::new(Some(I32), V128, |lane| I::I8x16ReplaceLane { lane: lane }, 0),
+            "i16x8.extract_lane_s" => LaneInstruction::new(None, I32, |lane| I::I16x8ExtractLaneS { lane: lane }, 1),
+            "i16x8.extract_lane_u" => LaneInstruction::new(None, I32, |lane| I::I16x8ExtractLaneU { lane: lane }, 1),
+            "i16x8.replace_lane" => LaneInstruction::new(Some(I32), V128, |lane| I::I16x8ReplaceLane { lane: lane }, 1),
+            "i32x4.extract_lane" => LaneInstruction::new(None, I32, |lane| I::I32x4ExtractLane { lane: lane }, 2),
+            "i32x4.replace_lane" => LaneInstruction::new(Some(I32), V128, |lane| I::I32x4ReplaceLane { lane: lane }, 2),
+            "i64x2.extract_lane" => LaneInstruction::new(None, I64, |lane| I::I64x2ExtractLane { lane: lane }, 3),
+            "i64x2.replace_lane" => LaneInstruction::new(Some(I64), V128, |lane| I::I64x2ReplaceLane { lane: lane }, 3),
+            "f32x4.extract_lane" => LaneInstruction::new(None, F64, |lane| I::F32x4ExtractLane { lane: lane }, 2),
+            "f32x4.replace_lane" => LaneInstruction::new(Some(F64), V128, |lane| I::F32x4ReplaceLane { lane: lane }, 2),
+            "f64x2.extract_lane" => LaneInstruction::new(None, F64, |lane| I::F64x2ExtractLane { lane: lane }, 3),
+            "f64x2.replace_lane" => LaneInstruction::new(Some(F64), V128, |lane| I::F64x2ReplaceLane { lane: lane }, 3),
             _ => return None,
         };
         return Some(ins);
@@ -533,16 +533,19 @@ impl MemInstruction {
 pub struct MemLaneInstruction {
     pub instruction: fn(MemArg, Lane) -> enc::Instruction<'static>,
     pub natural_alignment: u32,
+    pub lane_width: u32,
 }
 
 impl MemLaneInstruction {
     fn new(
         instruction: fn(MemArg, Lane) -> enc::Instruction<'static>,
         natural_alignment: u32,
+        lane_width: u32,
     ) -> MemLaneInstruction {
         MemLaneInstruction {
             instruction,
             natural_alignment,
+            lane_width
         }
     }
 }
@@ -551,6 +554,7 @@ pub struct LaneInstruction {
     pub param_type: Option<Type>,
     pub return_type: Type,
     pub instruction: fn(Lane) -> enc::Instruction<'static>,
+    pub lane_width: u32,
 }
 
 impl LaneInstruction {
@@ -558,11 +562,13 @@ impl LaneInstruction {
         param_type: Option<Type>,
         return_type: Type,
         instruction: fn(Lane) -> enc::Instruction<'static>,
+        lane_width: u32,
     ) -> LaneInstruction {
         LaneInstruction {
             param_type,
             return_type,
             instruction,
+            lane_width,
         }
     }
 }

--- a/src/intrinsics.rs
+++ b/src/intrinsics.rs
@@ -189,13 +189,13 @@ impl Intrinsics {
         self.inst("i32x4.extadd_pairwise_i16x8_s", &[V128], Some(V128), I::I32x4ExtAddPairwiseI16x8S);
         self.inst("i32x4.extadd_pairwise_i16x8_u", &[V128], Some(V128), I::I32x4ExtAddPairwiseI16x8U);
 
-        self.inst("i8x16.add_sat_s", &[V128, V128], Some(V128), I::I16x8AddSatS);
-        self.inst("i8x16.add_sat_u", &[V128, V128], Some(V128), I::I16x8AddSatU);
+        self.inst("i8x16.add_sat_s", &[V128, V128], Some(V128), I::I8x16AddSatS);
+        self.inst("i8x16.add_sat_u", &[V128, V128], Some(V128), I::I8x16AddSatU);
         self.inst("i16x8.add_sat_s", &[V128, V128], Some(V128), I::I16x8AddSatS);
         self.inst("i16x8.add_sat_u", &[V128, V128], Some(V128), I::I16x8AddSatU);
 
-        self.inst("i8x16.sub_sat_s", &[V128, V128], Some(V128), I::I16x8SubSatS);
-        self.inst("i8x16.sub_sat_u", &[V128, V128], Some(V128), I::I16x8SubSatU);
+        self.inst("i8x16.sub_sat_s", &[V128, V128], Some(V128), I::I8x16SubSatS);
+        self.inst("i8x16.sub_sat_u", &[V128, V128], Some(V128), I::I8x16SubSatU);
         self.inst("i16x8.sub_sat_s", &[V128, V128], Some(V128), I::I16x8SubSatS);
         self.inst("i16x8.sub_sat_u", &[V128, V128], Some(V128), I::I16x8SubSatU);
 
@@ -247,7 +247,7 @@ impl Intrinsics {
         self.inst("i64x2.shr_s", &[V128, I32], Some(V128), I::I64x2ShrS);
         self.inst("i64x2.shr_u", &[V128, I32], Some(V128), I::I64x2ShrU);
 
-        self.inst("v128.and", &[V128, V128], Some(V128), I::V128Not);
+        self.inst("v128.and", &[V128, V128], Some(V128), I::V128And);
         self.inst("v128.or", &[V128, V128], Some(V128), I::V128Or);
         self.inst("v128.xor", &[V128, V128], Some(V128), I::V128Xor);
         self.inst("v128.not", &[V128], Some(V128), I::V128Not);
@@ -499,8 +499,8 @@ impl Intrinsics {
             "i32x4.replace_lane" => LaneInstruction::new(Some(I32), V128, |lane| I::I32x4ReplaceLane { lane: lane }, 4),
             "i64x2.extract_lane" => LaneInstruction::new(None, I64, |lane| I::I64x2ExtractLane { lane: lane }, 2),
             "i64x2.replace_lane" => LaneInstruction::new(Some(I64), V128, |lane| I::I64x2ReplaceLane { lane: lane }, 2),
-            "f32x4.extract_lane" => LaneInstruction::new(None, F64, |lane| I::F32x4ExtractLane { lane: lane }, 4),
-            "f32x4.replace_lane" => LaneInstruction::new(Some(F64), V128, |lane| I::F32x4ReplaceLane { lane: lane }, 4),
+            "f32x4.extract_lane" => LaneInstruction::new(None, F32, |lane| I::F32x4ExtractLane { lane: lane }, 4),
+            "f32x4.replace_lane" => LaneInstruction::new(Some(F32), V128, |lane| I::F32x4ReplaceLane { lane: lane }, 4),
             "f64x2.extract_lane" => LaneInstruction::new(None, F64, |lane| I::F64x2ExtractLane { lane: lane }, 2),
             "f64x2.replace_lane" => LaneInstruction::new(Some(F64), V128, |lane| I::F64x2ReplaceLane { lane: lane }, 2),
             _ => return None,

--- a/src/intrinsics.rs
+++ b/src/intrinsics.rs
@@ -1,5 +1,6 @@
 use crate::ast::Type;
 use enc::MemArg;
+use enc::Lane;
 use std::collections::HashMap;
 use wasm_encoder as enc;
 
@@ -132,6 +133,240 @@ impl Intrinsics {
         self.inst("i64.trunc_sat_f64_s", &[F64], Some(I64), I::I64TruncSatF64S);
         self.inst("i64.trunc_sat_f64_u", &[F64], Some(I64), I::I64TruncSatF64U);
 
+        self.inst("i8x16.splat", &[I32], Some(V128), I::I8x16Splat);
+        self.inst("i16x8.splat", &[I32], Some(V128), I::I16x8Splat);
+        self.inst("i32x4.splat", &[I32], Some(V128), I::I32x4Splat);
+        self.inst("i64x2.splat", &[I64], Some(V128), I::I64x2Splat);
+        self.inst("f32x4.splat", &[F32], Some(V128), I::F32x4Splat);
+        self.inst("f64x2.splat", &[F64], Some(V128), I::F64x2Splat);
+
+        // skipped: i8x16.shuffle (requires special handling for 16 literal lane values)
+        self.inst("i8x16.swizzle", &[V128, V128], Some(V128), I::I8x16Swizzle);
+
+        self.inst("i8x16.add", &[V128, V128], Some(V128), I::I8x16Add);
+        self.inst("i16x8.add", &[V128, V128], Some(V128), I::I16x8Add);
+        self.inst("i32x4.add", &[V128, V128], Some(V128), I::I32x4Add);
+        self.inst("i64x2.add", &[V128, V128], Some(V128), I::I64x2Add);
+        self.inst("f32x4.add", &[V128, V128], Some(V128), I::F32x4Add);
+        self.inst("f64x2.add", &[V128, V128], Some(V128), I::F64x2Add);
+
+        self.inst("i8x16.sub", &[V128, V128], Some(V128), I::I8x16Sub);
+        self.inst("i16x8.sub", &[V128, V128], Some(V128), I::I16x8Sub);
+        self.inst("i32x4.sub", &[V128, V128], Some(V128), I::I32x4Sub);
+        self.inst("i64x2.sub", &[V128, V128], Some(V128), I::I64x2Sub);
+        self.inst("f32x4.sub", &[V128, V128], Some(V128), I::F32x4Sub);
+        self.inst("f64x2.sub", &[V128, V128], Some(V128), I::F64x2Sub);
+
+        self.inst("i16x8.mul", &[V128, V128], Some(V128), I::I16x8Mul);
+        self.inst("i32x4.mul", &[V128, V128], Some(V128), I::I32x4Mul);
+        self.inst("i64x2.mul", &[V128, V128], Some(V128), I::I64x2Mul);
+        self.inst("f32x4.mul", &[V128, V128], Some(V128), I::F32x4Mul);
+        self.inst("f64x2.mul", &[V128, V128], Some(V128), I::F64x2Mul);
+
+        self.inst("i32x4.dot_i16x8_s", &[V128, V128], Some(V128), I::I32x4DotI16x8S);
+
+        self.inst("i8x16.neg", &[V128, V128], Some(V128), I::I8x16Neg);
+        self.inst("i16x8.neg", &[V128, V128], Some(V128), I::I16x8Neg);
+        self.inst("i32x4.neg", &[V128, V128], Some(V128), I::I32x4Neg);
+        self.inst("i64x2.neg", &[V128, V128], Some(V128), I::I64x2Neg);
+        self.inst("f32x4.neg", &[V128, V128], Some(V128), I::F32x4Neg);
+        self.inst("f64x2.neg", &[V128, V128], Some(V128), I::F64x2Neg);
+
+        self.inst("i16x8.extmul_low_i8x16_s", &[V128, V128], Some(V128), I::I16x8ExtMulLowI8x16S);
+        self.inst("i16x8.extmul_high_i8x16_s", &[V128, V128], Some(V128), I::I16x8ExtMulHighI8x16S);
+        self.inst("i16x8.extmul_low_i8x16_u", &[V128, V128], Some(V128), I::I16x8ExtMulLowI8x16U);
+        self.inst("i16x8.extmul_high_i8x16_u", &[V128, V128], Some(V128), I::I16x8ExtMulHighI8x16U);
+        self.inst("i32x4.extmul_low_i16x8_s", &[V128, V128], Some(V128), I::I32x4ExtMulLowI16x8S);
+        self.inst("i32x4.extmul_high_i16x8_s", &[V128, V128], Some(V128), I::I32x4ExtMulHighI16x8S);
+        self.inst("i32x4.extmul_low_i16x8_u", &[V128, V128], Some(V128), I::I32x4ExtMulLowI16x8U);
+        self.inst("i32x4.extmul_high_i16x8_u", &[V128, V128], Some(V128), I::I32x4ExtMulHighI16x8U);
+        self.inst("i64x2.extmul_low_i32x4_s", &[V128, V128], Some(V128), I::I64x2ExtMulLowI32x4S);
+        self.inst("i64x2.extmul_high_i32x4_s", &[V128, V128], Some(V128), I::I64x2ExtMulHighI32x4S);
+        self.inst("i64x2.extmul_low_i32x4_u", &[V128, V128], Some(V128), I::I64x2ExtMulLowI32x4U);
+        self.inst("i64x2.extmul_high_i32x4_u", &[V128, V128], Some(V128), I::I64x2ExtMulHighI32x4U);
+
+        self.inst("i16x8.extadd_pairwise_i8x16_s", &[V128], Some(V128), I::I16x8ExtAddPairwiseI8x16S);
+        self.inst("i16x8.extadd_pairwise_i8x16_u", &[V128], Some(V128), I::I16x8ExtAddPairwiseI8x16U);
+        self.inst("i32x4.extadd_pairwise_i16x8_s", &[V128], Some(V128), I::I32x4ExtAddPairwiseI16x8S);
+        self.inst("i32x4.extadd_pairwise_i16x8_u", &[V128], Some(V128), I::I32x4ExtAddPairwiseI16x8U);
+
+        self.inst("i8x16.add_sat_s", &[V128, V128], Some(V128), I::I16x8AddSatS);
+        self.inst("i8x16.add_sat_u", &[V128, V128], Some(V128), I::I16x8AddSatU);
+        self.inst("i16x8.add_sat_s", &[V128, V128], Some(V128), I::I16x8AddSatS);
+        self.inst("i16x8.add_sat_u", &[V128, V128], Some(V128), I::I16x8AddSatU);
+
+        self.inst("i8x16.sub_sat_s", &[V128, V128], Some(V128), I::I16x8SubSatS);
+        self.inst("i8x16.sub_sat_u", &[V128, V128], Some(V128), I::I16x8SubSatU);
+        self.inst("i16x8.sub_sat_s", &[V128, V128], Some(V128), I::I16x8SubSatS);
+        self.inst("i16x8.sub_sat_u", &[V128, V128], Some(V128), I::I16x8SubSatU);
+
+        self.inst("i16x8.q15mulr_sat_s", &[V128, V128], Some(V128), I::I16x8Q15MulrSatS);
+
+        self.inst("i8x16.min_s", &[V128, V128], Some(V128), I::I8x16MinS);
+        self.inst("i8x16.min_u", &[V128, V128], Some(V128), I::I8x16MinU);
+        self.inst("i16x8.min_s", &[V128, V128], Some(V128), I::I16x8MinS);
+        self.inst("i16x8.min_u", &[V128, V128], Some(V128), I::I16x8MinU);
+        self.inst("i32x4.min_s", &[V128, V128], Some(V128), I::I32x4MinS);
+        self.inst("i32x4.min_u", &[V128, V128], Some(V128), I::I32x4MinU);
+        self.inst("f32x4.min", &[V128, V128], Some(V128), I::F32x4Min);
+        self.inst("f64x2.min", &[V128, V128], Some(V128), I::F64x2Min);
+        self.inst("f32x4.pmin", &[V128, V128], Some(V128), I::F32x4PMin);
+        self.inst("f64x2.pmin", &[V128, V128], Some(V128), I::F64x2PMin);
+
+        self.inst("i8x16.max_s", &[V128, V128], Some(V128), I::I8x16MaxS);
+        self.inst("i8x16.max_u", &[V128, V128], Some(V128), I::I8x16MaxU);
+        self.inst("i16x8.max_s", &[V128, V128], Some(V128), I::I16x8MaxS);
+        self.inst("i16x8.max_u", &[V128, V128], Some(V128), I::I16x8MaxU);
+        self.inst("i32x4.max_s", &[V128, V128], Some(V128), I::I32x4MaxS);
+        self.inst("i32x4.max_u", &[V128, V128], Some(V128), I::I32x4MaxU);
+        self.inst("f32x4.max", &[V128, V128], Some(V128), I::F32x4Max);
+        self.inst("f64x2.max", &[V128, V128], Some(V128), I::F64x2Max);
+        self.inst("f32x4.pmax", &[V128, V128], Some(V128), I::F32x4PMax);
+        self.inst("f64x2.pmax", &[V128, V128], Some(V128), I::F64x2PMax);
+
+        self.inst("i8x16.avgr_u", &[V128, V128], Some(V128), I::I8x16RoundingAverageU);
+        self.inst("i16x8.avgr_u", &[V128, V128], Some(V128), I::I16x8RoundingAverageU);
+
+        self.inst("i8x16.abs", &[V128], Some(V128), I::I8x16Abs);
+        self.inst("i16x8.abs", &[V128], Some(V128), I::I16x8Abs);
+        self.inst("i32x4.abs", &[V128], Some(V128), I::I32x4Abs);
+        self.inst("i64x2.abs", &[V128], Some(V128), I::I64x2Abs);
+        self.inst("f32x4.abs", &[V128], Some(V128), I::F32x4Abs);
+        self.inst("f64x2.abs", &[V128], Some(V128), I::F64x2Abs);
+
+        self.inst("i8x16.shl", &[V128, I32], Some(V128), I::I8x16Shl);
+        self.inst("i16x8.shl", &[V128, I32], Some(V128), I::I16x8Shl);
+        self.inst("i32x4.shl", &[V128, I32], Some(V128), I::I32x4Shl);
+        self.inst("i64x2.shl", &[V128, I32], Some(V128), I::I64x2Shl);
+
+        self.inst("i8x16.shr_s", &[V128, I32], Some(V128), I::I8x16ShrS);
+        self.inst("i8x16.shr_u", &[V128, I32], Some(V128), I::I8x16ShrU);
+        self.inst("i16x8.shr_s", &[V128, I32], Some(V128), I::I16x8ShrS);
+        self.inst("i16x8.shr_u", &[V128, I32], Some(V128), I::I16x8ShrU);
+        self.inst("i32x4.shr_s", &[V128, I32], Some(V128), I::I32x4ShrS);
+        self.inst("i32x4.shr_u", &[V128, I32], Some(V128), I::I32x4ShrU);
+        self.inst("i64x2.shr_s", &[V128, I32], Some(V128), I::I64x2ShrS);
+        self.inst("i64x2.shr_u", &[V128, I32], Some(V128), I::I64x2ShrU);
+
+        self.inst("v128.and", &[V128, V128], Some(V128), I::V128Not);
+        self.inst("v128.or", &[V128, V128], Some(V128), I::V128Or);
+        self.inst("v128.xor", &[V128, V128], Some(V128), I::V128Xor);
+        self.inst("v128.not", &[V128], Some(V128), I::V128Not);
+        self.inst("v128.andnot", &[V128, V128], Some(V128), I::V128AndNot);
+
+        self.inst("v128.bitselect", &[V128, V128, V128], Some(V128), I::V128Bitselect);
+
+        self.inst("i8x16.popcnt", &[V128], Some(V128), I::I8x16Popcnt);
+
+        self.inst("v128.any_true", &[V128], Some(I32), I::V128AnyTrue);
+        self.inst("i8x16.all_true", &[V128], Some(I32), I::I8x16AllTrue);
+        self.inst("i16x8.all_true", &[V128], Some(I32), I::I16x8AllTrue);
+        self.inst("i32x4.all_true", &[V128], Some(I32), I::I32x4AllTrue);
+        self.inst("i64x2.all_true", &[V128], Some(I32), I::I64x2AllTrue);
+
+        self.inst("i8x16.bitmask", &[V128], Some(I32), I::I8x16Bitmask);
+        self.inst("i16x8.bitmask", &[V128], Some(I32), I::I16x8Bitmask);
+        self.inst("i32x4.bitmask", &[V128], Some(I32), I::I32x4Bitmask);
+        self.inst("i64x2.bitmask", &[V128], Some(I32), I::I64x2Bitmask);
+
+        self.inst("i8x16.eq", &[V128, V128], Some(V128), I::I8x16Eq);
+        self.inst("i16x8.eq", &[V128, V128], Some(V128), I::I16x8Eq);
+        self.inst("i32x4.eq", &[V128, V128], Some(V128), I::I32x4Eq);
+        self.inst("i64x2.eq", &[V128, V128], Some(V128), I::I64x2Eq);
+        self.inst("f32x4.eq", &[V128, V128], Some(V128), I::F32x4Eq);
+        self.inst("f64x2.eq", &[V128, V128], Some(V128), I::F64x2Eq);
+
+        self.inst("i8x16.ne", &[V128, V128], Some(V128), I::I8x16Ne);
+        self.inst("i16x8.ne", &[V128, V128], Some(V128), I::I16x8Ne);
+        self.inst("i32x4.ne", &[V128, V128], Some(V128), I::I32x4Ne);
+        self.inst("i64x2.ne", &[V128, V128], Some(V128), I::I64x2Ne);
+        self.inst("f32x4.ne", &[V128, V128], Some(V128), I::F32x4Ne);
+        self.inst("f64x2.ne", &[V128, V128], Some(V128), I::F64x2Ne);
+
+        self.inst("i8x16.lt_s", &[V128, V128], Some(V128), I::I8x16LtS);
+        self.inst("i8x16.lt_u", &[V128, V128], Some(V128), I::I8x16LtU);
+        self.inst("i16x8.lt_s", &[V128, V128], Some(V128), I::I16x8LtS);
+        self.inst("i16x8.lt_u", &[V128, V128], Some(V128), I::I16x8LtU);
+        self.inst("i32x4.lt_s", &[V128, V128], Some(V128), I::I32x4LtS);
+        self.inst("i32x4.lt_u", &[V128, V128], Some(V128), I::I32x4LtU);
+        self.inst("f32x4.lt", &[V128, V128], Some(V128), I::F32x4Lt);
+        self.inst("f64x2.lt", &[V128, V128], Some(V128), I::F64x2Lt);
+
+        self.inst("i8x16.le_s", &[V128, V128], Some(V128), I::I8x16LeS);
+        self.inst("i8x16.le_u", &[V128, V128], Some(V128), I::I8x16LeU);
+        self.inst("i16x8.le_s", &[V128, V128], Some(V128), I::I16x8LeS);
+        self.inst("i16x8.le_u", &[V128, V128], Some(V128), I::I16x8LeU);
+        self.inst("i32x4.le_s", &[V128, V128], Some(V128), I::I32x4LeS);
+        self.inst("i32x4.le_u", &[V128, V128], Some(V128), I::I32x4LeU);
+        self.inst("f32x4.le", &[V128, V128], Some(V128), I::F32x4Le);
+        self.inst("f64x2.le", &[V128, V128], Some(V128), I::F64x2Le);
+
+        self.inst("i8x16.gt_s", &[V128, V128], Some(V128), I::I8x16GtS);
+        self.inst("i8x16.gt_u", &[V128, V128], Some(V128), I::I8x16GtU);
+        self.inst("i16x8.gt_s", &[V128, V128], Some(V128), I::I16x8GtS);
+        self.inst("i16x8.gt_u", &[V128, V128], Some(V128), I::I16x8GtU);
+        self.inst("i32x4.gt_s", &[V128, V128], Some(V128), I::I32x4GtS);
+        self.inst("i32x4.gt_u", &[V128, V128], Some(V128), I::I32x4GtU);
+        self.inst("f32x4.gt", &[V128, V128], Some(V128), I::F32x4Gt);
+        self.inst("f64x2.gt", &[V128, V128], Some(V128), I::F64x2Gt);
+
+        self.inst("i8x16.ge_s", &[V128, V128], Some(V128), I::I8x16GeS);
+        self.inst("i8x16.ge_u", &[V128, V128], Some(V128), I::I8x16GeU);
+        self.inst("i16x8.ge_s", &[V128, V128], Some(V128), I::I16x8GeS);
+        self.inst("i16x8.ge_u", &[V128, V128], Some(V128), I::I16x8GeU);
+        self.inst("i32x4.ge_s", &[V128, V128], Some(V128), I::I32x4GeS);
+        self.inst("i32x4.ge_u", &[V128, V128], Some(V128), I::I32x4GeU);
+        self.inst("f32x4.ge", &[V128, V128], Some(V128), I::F32x4Ge);
+        self.inst("f64x2.ge", &[V128, V128], Some(V128), I::F64x2Ge);
+
+        self.inst("f32x4.div", &[V128, V128], Some(V128), I::F32x4Div);
+        self.inst("f64x2.div", &[V128, V128], Some(V128), I::F64x2Div);
+
+        self.inst("f32x4.sqrt", &[V128], Some(V128), I::F32x4Sqrt);
+        self.inst("f64x2.sqrt", &[V128], Some(V128), I::F64x2Sqrt);
+
+        self.inst("f32x4.ceil", &[V128], Some(V128), I::F32x4Ceil);
+        self.inst("f64x2.ceil", &[V128], Some(V128), I::F64x2Ceil);
+        self.inst("f32x4.floor", &[V128], Some(V128), I::F32x4Floor);
+        self.inst("f64x2.floor", &[V128], Some(V128), I::F64x2Floor);
+        self.inst("f32x4.trunc", &[V128], Some(V128), I::F32x4Trunc);
+        self.inst("f64x2.trunc", &[V128], Some(V128), I::F64x2Trunc);
+        self.inst("f32x4.nearest", &[V128], Some(V128), I::F32x4Nearest);
+        self.inst("f64x2.nearest", &[V128], Some(V128), I::F64x2Nearest);
+
+        self.inst("f32x4.convert_i32x4_s", &[V128], Some(V128), I::F32x4ConvertI32x4S);
+        self.inst("f32x4.convert_i32x4_u", &[V128], Some(V128), I::F32x4ConvertI32x4U);
+
+        self.inst("f64x2.convert_low_i32x4_s", &[V128], Some(V128), I::F64x2ConvertLowI32x4S);
+        self.inst("f64x2.convert_low_i32x4_u", &[V128], Some(V128), I::F64x2ConvertLowI32x4U);
+
+        self.inst("i32x4.trunc_sat_f32x4_s", &[V128], Some(V128), I::I32x4TruncSatF32x4S);
+        self.inst("i32x4.trunc_sat_f32x4_u", &[V128], Some(V128), I::I32x4TruncSatF32x4U);
+
+        self.inst("i32x4.trunc_sat_f64x2_s_zero", &[V128], Some(V128), I::I32x4TruncSatF64x2SZero);
+        self.inst("i32x4.trunc_sat_f64x2_u_zero", &[V128], Some(V128), I::I32x4TruncSatF64x2UZero);
+
+        self.inst("f32x4.demote_f64x2_zero", &[V128], Some(V128), I::F32x4DemoteF64x2Zero);
+        self.inst("f64x2.promote_low_f32x4", &[V128], Some(V128), I::F64x2PromoteLowF32x4);
+
+        self.inst("i8x16.narrow_i16x8_s", &[V128, V128], Some(V128), I::I8x16NarrowI16x8S);
+        self.inst("i8x16.narrow_i16x8_u", &[V128, V128], Some(V128), I::I8x16NarrowI16x8U);
+        self.inst("i16x8.narrow_i32x4_s", &[V128, V128], Some(V128), I::I16x8NarrowI32x4S);
+        self.inst("i16x8.narrow_i32x4_u", &[V128, V128], Some(V128), I::I16x8NarrowI32x4U);
+
+        self.inst("i16x8.extend_low_i8x16_s", &[V128], Some(V128), I::I16x8ExtendLowI8x16S);
+        self.inst("i16x8.extend_high_i8x16_s", &[V128], Some(V128), I::I16x8ExtendHighI8x16S);
+        self.inst("i16x8.extend_low_i8x16_u", &[V128], Some(V128), I::I16x8ExtendLowI8x16U);
+        self.inst("i16x8.extend_high_i8x16_u", &[V128], Some(V128), I::I16x8ExtendHighI8x16U);
+        self.inst("i32x4.extend_low_i16x8_s", &[V128], Some(V128), I::I32x4ExtendLowI16x8S);
+        self.inst("i32x4.extend_high_i16x8_s", &[V128], Some(V128), I::I32x4ExtendHighI16x8S);
+        self.inst("i32x4.extend_low_i16x8_u", &[V128], Some(V128), I::I32x4ExtendLowI16x8U);
+        self.inst("i32x4.extend_high_i16x8_u", &[V128], Some(V128), I::I32x4ExtendHighI16x8U);
+        self.inst("i64x2.extend_low_i32x4_s", &[V128], Some(V128), I::I64x2ExtendLowI32x4S);
+        self.inst("i64x2.extend_high_i32x4_s", &[V128], Some(V128), I::I64x2ExtendHighI32x4S);
+        self.inst("i64x2.extend_low_i32x4_u", &[V128], Some(V128), I::I64x2ExtendLowI32x4U);
+        self.inst("i64x2.extend_high_i32x4_u", &[V128], Some(V128), I::I64x2ExtendHighI32x4U);
+
         self.inst(
             "memory.copy",
             &[I32, I32, I32],
@@ -190,6 +425,32 @@ impl Intrinsics {
             "i64.load32_u" => MemInstruction::new(I64, I::I64Load32_U, 2),
             "f32.load" => MemInstruction::new(F32, I::F32Load, 2),
             "f64.load" => MemInstruction::new(F64, I::F64Load, 3),
+            "v128.load" => MemInstruction::new(V128, |memarg| I::V128Load { memarg: memarg }, 4),
+            "v128.load8x8_s" => MemInstruction::new(V128, |memarg| I::V128Load8x8S { memarg: memarg }, 3),
+            "v128.load8x8_u" => MemInstruction::new(V128, |memarg| I::V128Load8x8U { memarg: memarg }, 3),
+            "v128.load16x4_s" => MemInstruction::new(V128, |memarg| I::V128Load16x4S { memarg: memarg }, 3),
+            "v128.load16x4_u" => MemInstruction::new(V128, |memarg| I::V128Load16x4U { memarg: memarg }, 3),
+            "v128.load32x2_s" => MemInstruction::new(V128, |memarg| I::V128Load32x2S { memarg: memarg }, 3),
+            "v128.load32x2_u" => MemInstruction::new(V128, |memarg| I::V128Load32x2U { memarg: memarg }, 3),
+            "v128.load8_splat" => MemInstruction::new(V128, |memarg| I::V128Load8Splat { memarg: memarg }, 0),
+            "v128.load16_splat" => MemInstruction::new(V128, |memarg| I::V128Load16Splat { memarg: memarg }, 1),
+            "v128.load32_splat" => MemInstruction::new(V128, |memarg| I::V128Load32Splat { memarg: memarg }, 2),
+            "v128.load64_splat" => MemInstruction::new(V128, |memarg| I::V128Load64Splat { memarg: memarg }, 3),
+            "v128.load32_zero" => MemInstruction::new(V128, |memarg| I::V128Load32Zero { memarg: memarg }, 2),
+            "v128.load64_zero" => MemInstruction::new(V128, |memarg| I::V128Load64Zero { memarg: memarg }, 3),
+            _ => return None,
+        };
+        return Some(ins);
+    }
+
+    pub fn find_load_lane(&self, name: &str) -> Option<MemLaneInstruction> {
+        use enc::Instruction as I;
+        use Type::*;
+        let ins = match name {
+            "v128.load8_lane" => MemLaneInstruction::new(V128, |memarg, lane| I::V128Load8Lane { memarg: memarg, lane: lane }, 0),
+            "v128.load16_lane" => MemLaneInstruction::new(V128, |memarg, lane| I::V128Load16Lane { memarg: memarg, lane: lane }, 1),
+            "v128.load32_lane" => MemLaneInstruction::new(V128, |memarg, lane| I::V128Load32Lane { memarg: memarg, lane: lane }, 2),
+            "v128.load64_lane" => MemLaneInstruction::new(V128, |memarg, lane| I::V128Load64Lane { memarg: memarg, lane: lane }, 3),
             _ => return None,
         };
         return Some(ins);
@@ -208,6 +469,43 @@ impl Intrinsics {
             "i64.store32" => MemInstruction::new(I64, I::I64Store32, 2),
             "f32.store" => MemInstruction::new(F32, I::F32Store, 2),
             "f64.store" => MemInstruction::new(F64, I::F64Store, 3),
+            "v128.store" => MemInstruction::new(V128, |memarg| I::V128Store { memarg: memarg }, 4),
+            _ => return None,
+        };
+        return Some(ins);
+    }
+
+    pub fn find_store_lane(&self, name: &str) -> Option<MemLaneInstruction> {
+        use enc::Instruction as I;
+        use Type::*;
+        let ins = match name {
+            "v128.store8_lane" => MemLaneInstruction::new(V128, |memarg, lane| I::V128Store8Lane { memarg: memarg, lane: lane }, 0),
+            "v128.store16_lane" => MemLaneInstruction::new(V128, |memarg, lane| I::V128Store16Lane { memarg: memarg, lane: lane }, 1),
+            "v128.store32_lane" => MemLaneInstruction::new(V128, |memarg, lane| I::V128Store32Lane { memarg: memarg, lane: lane }, 2),
+            "v128.store64_lane" => MemLaneInstruction::new(V128, |memarg, lane| I::V128Store64Lane { memarg: memarg, lane: lane }, 3),
+            _ => return None,
+        };
+        return Some(ins);
+    }
+
+    pub fn find_lane(&self, name: &str) -> Option<LaneInstruction> {
+        use enc::Instruction as I;
+        use Type::*;
+        let ins = match name {
+            "i8x16.extract_lane_s" => LaneInstruction::new(None, I32, |lane| I::I8x16ExtractLaneS { lane: lane }),
+            "i8x16.extract_lane_u" => LaneInstruction::new(None, I32, |lane| I::I8x16ExtractLaneU { lane: lane }),
+            "i8x16.replace_lane" => LaneInstruction::new(Some(I32), V128, |lane| I::I8x16ReplaceLane { lane: lane }),
+            "i16x8.extract_lane_s" => LaneInstruction::new(None, I32, |lane| I::I16x8ExtractLaneS { lane: lane }),
+            "i16x8.extract_lane_u" => LaneInstruction::new(None, I32, |lane| I::I16x8ExtractLaneU { lane: lane }),
+            "i16x8.replace_lane" => LaneInstruction::new(Some(I32), V128, |lane| I::I16x8ReplaceLane { lane: lane }),
+            "i32x4.extract_lane" => LaneInstruction::new(None, I32, |lane| I::I32x4ExtractLane { lane: lane }),
+            "i32x4.replace_lane" => LaneInstruction::new(Some(I32), V128, |lane| I::I32x4ReplaceLane { lane: lane }),
+            "i64x2.extract_lane" => LaneInstruction::new(None, I64, |lane| I::I64x2ExtractLane { lane: lane }),
+            "i64x2.replace_lane" => LaneInstruction::new(Some(I64), V128, |lane| I::I64x2ReplaceLane { lane: lane }),
+            "f32x4.extract_lane" => LaneInstruction::new(None, F64, |lane| I::F32x4ExtractLane { lane: lane }),
+            "f32x4.replace_lane" => LaneInstruction::new(Some(F64), V128, |lane| I::F32x4ReplaceLane { lane: lane }),
+            "f64x2.extract_lane" => LaneInstruction::new(None, F64, |lane| I::F64x2ExtractLane { lane: lane }),
+            "f64x2.replace_lane" => LaneInstruction::new(Some(F64), V128, |lane| I::F64x2ReplaceLane { lane: lane }),
             _ => return None,
         };
         return Some(ins);
@@ -230,6 +528,46 @@ impl MemInstruction {
             type_,
             instruction,
             natural_alignment,
+        }
+    }
+}
+
+pub struct MemLaneInstruction {
+    pub type_: Type,
+    pub instruction: fn(MemArg, Lane) -> enc::Instruction<'static>,
+    pub natural_alignment: u32,
+}
+
+impl MemLaneInstruction {
+    fn new(
+        type_: Type,
+        instruction: fn(MemArg, Lane) -> enc::Instruction<'static>,
+        natural_alignment: u32,
+    ) -> MemLaneInstruction {
+        MemLaneInstruction {
+            type_,
+            instruction,
+            natural_alignment,
+        }
+    }
+}
+
+pub struct LaneInstruction {
+    pub param_type: Option<Type>,
+    pub return_type: Type,
+    pub instruction: fn(Lane) -> enc::Instruction<'static>,
+}
+
+impl LaneInstruction {
+    fn new(
+        param_type: Option<Type>,
+        return_type: Type,
+        instruction: fn(Lane) -> enc::Instruction<'static>,
+    ) -> LaneInstruction {
+        LaneInstruction {
+            param_type,
+            return_type,
+            instruction,
         }
     }
 }

--- a/src/intrinsics.rs
+++ b/src/intrinsics.rs
@@ -140,7 +140,6 @@ impl Intrinsics {
         self.inst("f32x4.splat", &[F32], Some(V128), I::F32x4Splat);
         self.inst("f64x2.splat", &[F64], Some(V128), I::F64x2Splat);
 
-        // skipped: i8x16.shuffle (requires special handling for 16 literal lane values)
         self.inst("i8x16.swizzle", &[V128, V128], Some(V128), I::I8x16Swizzle);
 
         self.inst("i8x16.add", &[V128, V128], Some(V128), I::I8x16Add);
@@ -446,10 +445,10 @@ impl Intrinsics {
     pub fn find_load_lane(&self, name: &str) -> Option<MemLaneInstruction> {
         use enc::Instruction as I;
         let ins = match name {
-            "v128.load8_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Load8Lane { memarg: memarg, lane: lane }, 0, 0),
-            "v128.load16_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Load16Lane { memarg: memarg, lane: lane }, 1, 1),
-            "v128.load32_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Load32Lane { memarg: memarg, lane: lane }, 2, 2),
-            "v128.load64_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Load64Lane { memarg: memarg, lane: lane }, 3, 3),
+            "v128.load8_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Load8Lane { memarg: memarg, lane: lane }, 0, 16),
+            "v128.load16_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Load16Lane { memarg: memarg, lane: lane }, 1, 8),
+            "v128.load32_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Load32Lane { memarg: memarg, lane: lane }, 2, 4),
+            "v128.load64_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Load64Lane { memarg: memarg, lane: lane }, 3, 2),
             _ => return None,
         };
         return Some(ins);
@@ -477,10 +476,10 @@ impl Intrinsics {
     pub fn find_store_lane(&self, name: &str) -> Option<MemLaneInstruction> {
         use enc::Instruction as I;
         let ins = match name {
-            "v128.store8_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Store8Lane { memarg: memarg, lane: lane }, 0, 0),
-            "v128.store16_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Store16Lane { memarg: memarg, lane: lane }, 1, 1),
-            "v128.store32_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Store32Lane { memarg: memarg, lane: lane }, 2, 2),
-            "v128.store64_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Store64Lane { memarg: memarg, lane: lane }, 3, 3),
+            "v128.store8_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Store8Lane { memarg: memarg, lane: lane }, 0, 16),
+            "v128.store16_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Store16Lane { memarg: memarg, lane: lane }, 1, 8),
+            "v128.store32_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Store32Lane { memarg: memarg, lane: lane }, 2, 4),
+            "v128.store64_lane" => MemLaneInstruction::new(|memarg, lane| I::V128Store64Lane { memarg: memarg, lane: lane }, 3, 2),
             _ => return None,
         };
         return Some(ins);
@@ -490,20 +489,29 @@ impl Intrinsics {
         use enc::Instruction as I;
         use Type::*;
         let ins = match name {
-            "i8x16.extract_lane_s" => LaneInstruction::new(None, I32, |lane| I::I8x16ExtractLaneS { lane: lane }, 0),
-            "i8x16.extract_lane_u" => LaneInstruction::new(None, I32, |lane| I::I8x16ExtractLaneU { lane: lane }, 0),
-            "i8x16.replace_lane" => LaneInstruction::new(Some(I32), V128, |lane| I::I8x16ReplaceLane { lane: lane }, 0),
-            "i16x8.extract_lane_s" => LaneInstruction::new(None, I32, |lane| I::I16x8ExtractLaneS { lane: lane }, 1),
-            "i16x8.extract_lane_u" => LaneInstruction::new(None, I32, |lane| I::I16x8ExtractLaneU { lane: lane }, 1),
-            "i16x8.replace_lane" => LaneInstruction::new(Some(I32), V128, |lane| I::I16x8ReplaceLane { lane: lane }, 1),
-            "i32x4.extract_lane" => LaneInstruction::new(None, I32, |lane| I::I32x4ExtractLane { lane: lane }, 2),
-            "i32x4.replace_lane" => LaneInstruction::new(Some(I32), V128, |lane| I::I32x4ReplaceLane { lane: lane }, 2),
-            "i64x2.extract_lane" => LaneInstruction::new(None, I64, |lane| I::I64x2ExtractLane { lane: lane }, 3),
-            "i64x2.replace_lane" => LaneInstruction::new(Some(I64), V128, |lane| I::I64x2ReplaceLane { lane: lane }, 3),
-            "f32x4.extract_lane" => LaneInstruction::new(None, F64, |lane| I::F32x4ExtractLane { lane: lane }, 2),
-            "f32x4.replace_lane" => LaneInstruction::new(Some(F64), V128, |lane| I::F32x4ReplaceLane { lane: lane }, 2),
-            "f64x2.extract_lane" => LaneInstruction::new(None, F64, |lane| I::F64x2ExtractLane { lane: lane }, 3),
-            "f64x2.replace_lane" => LaneInstruction::new(Some(F64), V128, |lane| I::F64x2ReplaceLane { lane: lane }, 3),
+            "i8x16.extract_lane_s" => LaneInstruction::new(None, I32, |lane| I::I8x16ExtractLaneS { lane: lane }, 16),
+            "i8x16.extract_lane_u" => LaneInstruction::new(None, I32, |lane| I::I8x16ExtractLaneU { lane: lane }, 16),
+            "i8x16.replace_lane" => LaneInstruction::new(Some(I32), V128, |lane| I::I8x16ReplaceLane { lane: lane }, 16),
+            "i16x8.extract_lane_s" => LaneInstruction::new(None, I32, |lane| I::I16x8ExtractLaneS { lane: lane }, 8),
+            "i16x8.extract_lane_u" => LaneInstruction::new(None, I32, |lane| I::I16x8ExtractLaneU { lane: lane }, 8),
+            "i16x8.replace_lane" => LaneInstruction::new(Some(I32), V128, |lane| I::I16x8ReplaceLane { lane: lane }, 8),
+            "i32x4.extract_lane" => LaneInstruction::new(None, I32, |lane| I::I32x4ExtractLane { lane: lane }, 4),
+            "i32x4.replace_lane" => LaneInstruction::new(Some(I32), V128, |lane| I::I32x4ReplaceLane { lane: lane }, 4),
+            "i64x2.extract_lane" => LaneInstruction::new(None, I64, |lane| I::I64x2ExtractLane { lane: lane }, 2),
+            "i64x2.replace_lane" => LaneInstruction::new(Some(I64), V128, |lane| I::I64x2ReplaceLane { lane: lane }, 2),
+            "f32x4.extract_lane" => LaneInstruction::new(None, F64, |lane| I::F32x4ExtractLane { lane: lane }, 4),
+            "f32x4.replace_lane" => LaneInstruction::new(Some(F64), V128, |lane| I::F32x4ReplaceLane { lane: lane }, 4),
+            "f64x2.extract_lane" => LaneInstruction::new(None, F64, |lane| I::F64x2ExtractLane { lane: lane }, 2),
+            "f64x2.replace_lane" => LaneInstruction::new(Some(F64), V128, |lane| I::F64x2ReplaceLane { lane: lane }, 2),
+            _ => return None,
+        };
+        return Some(ins);
+    }
+
+    pub fn find_shuffle(&self, name: &str) -> Option<ShuffleInstruction> {
+        use enc::Instruction as I;
+        let ins = match name {
+            "i8x16.shuffle" => ShuffleInstruction::new(|lanes| I::I8x16Shuffle { lanes: lanes }, 32),
             _ => return None,
         };
         return Some(ins);
@@ -533,19 +541,19 @@ impl MemInstruction {
 pub struct MemLaneInstruction {
     pub instruction: fn(MemArg, Lane) -> enc::Instruction<'static>,
     pub natural_alignment: u32,
-    pub lane_width: u32,
+    pub num_lanes: u32,
 }
 
 impl MemLaneInstruction {
     fn new(
         instruction: fn(MemArg, Lane) -> enc::Instruction<'static>,
         natural_alignment: u32,
-        lane_width: u32,
+        num_lanes: u32,
     ) -> MemLaneInstruction {
         MemLaneInstruction {
             instruction,
             natural_alignment,
-            lane_width
+            num_lanes
         }
     }
 }
@@ -554,7 +562,7 @@ pub struct LaneInstruction {
     pub param_type: Option<Type>,
     pub return_type: Type,
     pub instruction: fn(Lane) -> enc::Instruction<'static>,
-    pub lane_width: u32,
+    pub num_lanes: u32,
 }
 
 impl LaneInstruction {
@@ -562,13 +570,30 @@ impl LaneInstruction {
         param_type: Option<Type>,
         return_type: Type,
         instruction: fn(Lane) -> enc::Instruction<'static>,
-        lane_width: u32,
+        num_lanes: u32,
     ) -> LaneInstruction {
         LaneInstruction {
             param_type,
             return_type,
             instruction,
-            lane_width,
+            num_lanes,
+        }
+    }
+}
+
+pub struct ShuffleInstruction {
+    pub instruction: fn([Lane; 16]) -> enc::Instruction<'static>,
+    pub num_lanes: u32,
+}
+
+impl ShuffleInstruction {
+    fn new(
+        instruction: fn([Lane; 16]) -> enc::Instruction<'static>,
+        num_lanes: u32,
+    ) -> ShuffleInstruction {
+        ShuffleInstruction {
+            instruction,
+            num_lanes,
         }
     }
 }

--- a/src/intrinsics.rs
+++ b/src/intrinsics.rs
@@ -164,12 +164,12 @@ impl Intrinsics {
 
         self.inst("i32x4.dot_i16x8_s", &[V128, V128], Some(V128), I::I32x4DotI16x8S);
 
-        self.inst("i8x16.neg", &[V128, V128], Some(V128), I::I8x16Neg);
-        self.inst("i16x8.neg", &[V128, V128], Some(V128), I::I16x8Neg);
-        self.inst("i32x4.neg", &[V128, V128], Some(V128), I::I32x4Neg);
-        self.inst("i64x2.neg", &[V128, V128], Some(V128), I::I64x2Neg);
-        self.inst("f32x4.neg", &[V128, V128], Some(V128), I::F32x4Neg);
-        self.inst("f64x2.neg", &[V128, V128], Some(V128), I::F64x2Neg);
+        self.inst("i8x16.neg", &[V128], Some(V128), I::I8x16Neg);
+        self.inst("i16x8.neg", &[V128], Some(V128), I::I16x8Neg);
+        self.inst("i32x4.neg", &[V128], Some(V128), I::I32x4Neg);
+        self.inst("i64x2.neg", &[V128], Some(V128), I::I64x2Neg);
+        self.inst("f32x4.neg", &[V128], Some(V128), I::F32x4Neg);
+        self.inst("f64x2.neg", &[V128], Some(V128), I::F64x2Neg);
 
         self.inst("i16x8.extmul_low_i8x16_s", &[V128, V128], Some(V128), I::I16x8ExtMulLowI8x16S);
         self.inst("i16x8.extmul_high_i8x16_s", &[V128, V128], Some(V128), I::I16x8ExtMulHighI8x16S);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -79,8 +79,8 @@ enum Token {
     Str(String),
     Int(i32),
     Int64(i64),
-    IntFloat(i32),
     Int128(i128),
+    IntFloat(i32),
     Float(String),
     Float64(String),
     Op(String),
@@ -266,10 +266,10 @@ fn lexer() -> impl Parser<char, Vec<(Token, Span)>, Error = LexerError> {
     let integer = just::<_, _, LexerError>("0x")
         .ignore_then(text::digits(16))
         .try_map(|n, span| {
-            u64::from_str_radix(&n, 16).map_err(|err| LexerError::custom(span, err.to_string()))
+            u128::from_str_radix(&n, 16).map_err(|err| LexerError::custom(span, err.to_string()))
         })
         .or(text::digits(10).try_map(|n: String, span: Span| {
-            n.parse::<u64>()
+            n.parse::<u128>()
                 .map_err(|err| LexerError::custom(span, err.to_string()))
         }))
         .boxed();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1099,6 +1099,7 @@ fn script_parser() -> impl Parser<Token, ast::Script, Error = ScriptError> + Clo
             .or(just(Token::Ident("i16".to_string())).to(ast::DataType::I16))
             .or(just(Token::Ident("i32".to_string())).to(ast::DataType::I32))
             .or(just(Token::Ident("i64".to_string())).to(ast::DataType::I64))
+            .or(just(Token::Ident("i128".to_string())).to(ast::DataType::I128))
             .or(just(Token::Ident("f32".to_string())).to(ast::DataType::F32))
             .or(just(Token::Ident("f64".to_string())).to(ast::DataType::F64))
             .then(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -281,7 +281,7 @@ fn lexer() -> impl Parser<char, Vec<(Token, Span)>, Error = LexerError> {
 
     let int128 = integer
         .clone()
-        .then_ignore(just("v128"))
+        .then_ignore(just("i128"))
         .map(|n| Token::Int128(n as i128));
 
     let int_float = integer

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -231,6 +231,7 @@ pub fn tc_script(script: &mut ast::Script, sources: &Sources) -> Result<()> {
                             ast::Type::I32
                         }
                         ast::DataType::I64 => ast::Type::I64,
+                        ast::DataType::I128 => ast::Type::V128,
                         ast::DataType::F32 => ast::Type::F32,
                         ast::DataType::F64 => ast::Type::F64,
                     };

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -1018,6 +1018,7 @@ fn tc_lane(lane_width: u32, context: &mut Context, param: &mut ast::Expression, 
     if param.type_ != Some(I32) {
         return type_mismatch(Some(I32), &span, param.type_, &param.span, context.sources);
     }
+    tc_const(param, context.sources)?;
     let lane = param.const_i32();
     let max_lane = (16 >> lane_width) - 1;
     if lane < 0 || lane > max_lane {


### PR DESCRIPTION
I present: a silky-smooth yak. I've tried to add support for the v128 type and WASM SIMD intrinsics.

Major warning: I have never written Rust before.

The biggest challenge I encountered was supporting instructions that take lane parameters. Following the way load and store instructions are treated now, I've added special handling for two new kinds of instructions: `MemLaneInstruction` (loads and stores) and `LaneInstruction` (extract and replace lane). I'm not happy with my naming or the very copy/paste way that these new formats are handled. I'm sure something much better could happen here but I'm not comfortable enough with either Rust or the existing codebase to be sure what that would be.

In addition to the v128 type and SIMD intrinsics, there's also a new i128 literal type, handled (hopefully) analogously to existing i64 literals.

I have done rudimentary spot checks of v128 constants, non-lane/non-memory SIMD operations, lane loads, lane stores, lane extractions, and lane replacements. At least one or two representative intrinsics in each of these classes seem to function correctly. That's been about the extent of my testing, however.

A few other warnings / deficiencies:
* The lane typecheck verifies only that lane values are in the 0-15 range - it does not adapt properly to instruction lane size.
* I didn't implement shuffle, since it would take some special handling.
* I would be shocked if I transcribed all of the SIMD intrinsics and their typings correctly.
 
Formats for the new classes of instructions are:

```
v128.store32_lane(v128_value, lane_idx, ...memarg);
v128.load32_splat(v128_value, lane_idx, ...memarg);
i32x4.extract_lane(v128_value, lane_idx);
i32x4.replace_lane(v128_value, lane_idx, i32_value);
```

And here is a quick and dirty smoke test:

```
include "./microw8-api.cwa"

export fn upd() {
    let v = i32x4.replace_lane(i32x4.splat(255), 1, 20);
    v128.store32_lane(v, 1, USER_MEM);
    v=v128.load32_lane(v, 2, USER_MEM);
    cls(i32x4.extract_lane(v128.load32_lane(v, 2, 0, USER_MEM),2));
}
```

Let me know if this is something you'd potentially be interested in merging, and if so what you'd need to make that happen. 